### PR TITLE
[WIP] initiall version of PR test jobs

### DIFF
--- a/jobs/build-triggers/tendrl-build-triggers-pr-tests.yml
+++ b/jobs/build-triggers/tendrl-build-triggers-pr-tests.yml
@@ -151,6 +151,8 @@
       - git:
           url: 'https://github.com/Tendrl/{package_name}'
           refspec: "+refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*"
+          branches:
+            - "origin/pr/**"
           basedir: tendrl-{package_name}
           skip-tag: true
           wipe-workspace: true

--- a/jobs/build-triggers/tendrl-build-triggers-pr-tests.yml
+++ b/jobs/build-triggers/tendrl-build-triggers-pr-tests.yml
@@ -84,10 +84,7 @@
           # Prepare env.sh file
           echo > ${{WORKSPACE}}/env.sh
           # use cop tendrl/tendrl (master) repo
-          echo "TENDRL_REPO_URL=http://copr-be.cloud.fedoraproject.org/results/tendrl/tendrl/epel-7-x86_64/" >> ${{WORKSPACE}}/env.sh
-          echo "TENDRL_REPO_GPGKEY_URL=https://copr-be.cloud.fedoraproject.org/results/tendrl/tendrl/pubkey.gpg" >> ${{WORKSPACE}}/env.sh
-          echo "TENDRL_DEPENDENCIES_REPO_URL=http://copr-be.cloud.fedoraproject.org/results/tendrl/dependencies/epel-7-x86_64/" >> ${{WORKSPACE}}/env.sh
-          echo "TENDRL_DEPENDENCIES_REPO_GPGKEY_URL=https://copr-be.cloud.fedoraproject.org/results/tendrl/dependencies/pubkey.gpg" >> ${{WORKSPACE}}/env.sh
+          echo "TENDRL_REPO=master" >> ${{WORKSPACE}}/env.sh
           # configure additional repos
           echo "ADDITIONAL_REPOS=${{ADDITIONAL_REPOS}}" >> ${{WORKSPACE}}/env.sh
           echo "ADDITIONAL_REPOS_USM_SERVER=${{ADDITIONAL_REPOS_USM_SERVER}}" >> ${{WORKSPACE}}/env.sh

--- a/jobs/build-triggers/tendrl-build-triggers-pr-tests.yml
+++ b/jobs/build-triggers/tendrl-build-triggers-pr-tests.yml
@@ -81,10 +81,6 @@
             echo
           fi
 
-          echo "Run whole test suite."
-          echo "##############################################################"
-          echo
-
           # Prepare env.sh file
           echo > ${{WORKSPACE}}/env.sh
           # use cop tendrl/tendrl (master) repo
@@ -97,7 +93,12 @@
           echo "ADDITIONAL_REPOS_USM_SERVER=${{ADDITIONAL_REPOS_USM_SERVER}}" >> ${{WORKSPACE}}/env.sh
           echo "ADDITIONAL_REPOS_USM_NODES=${{ADDITIONAL_REPOS_USM_NODES}}" >> ${{WORKSPACE}}/env.sh
           echo "ADDITIONAL_REPOS_USM_CLIENT=${{ADDITIONAL_REPOS_USM_CLIENT}}" >> ${{WORKSPACE}}/env.sh
+          set +x
 
+          echo
+          echo "##############################################################"
+          echo "Run whole test suite."
+          echo
       - trigger-builds:
         - project: "tendrl-2-cluster-gluster"
           property-file: env.sh

--- a/jobs/build-triggers/tendrl-build-triggers-pr-tests.yml
+++ b/jobs/build-triggers/tendrl-build-triggers-pr-tests.yml
@@ -100,14 +100,14 @@
           echo "Run whole test suite."
           echo
       - trigger-builds:
-        - project: "tendrl-2-cluster-gluster"
-          property-file: env.sh
-          block: true
+          - project: "tendrl-2-cluster-gluster"
+            property-file: env.sh
+            block: true
 
     publishers:
       - email:
           recipients: dahorak@redhat.com
-            
+
 
 - project:
     name: 'Test_suite'

--- a/jobs/build-triggers/tendrl-build-triggers-pr-tests.yml
+++ b/jobs/build-triggers/tendrl-build-triggers-pr-tests.yml
@@ -1,0 +1,141 @@
+---
+- job-template:
+    name: "tendrl-pr-trigger-tests-{package_name}"
+    display-name: 'Tendrl test (PR) - {package_name}'
+    description: |
+      <b>Job triggering test suite execution.</b><br>
+      <br>
+      It might be triggered by following phrase in comment in the respective PR:
+      <pre>
+      run tests
+      </pre>
+      And it is also possible to specify dependencies on PRs from other repos
+      in following format (in the PR description or in the comment triggering
+      the tests)
+      <pre>
+      Depends on: &lt;repo-name&gt;/pr&lt;pr_id&gt; &lt;repo2-name&gt;/pr&lt;pr2_id&gt;
+      </pre>
+      where <i>&lt;repo-name&gt;</i> is repo name including <i>tendrl-</i> prefix
+      and &lt;pr_id&gt; is PR number.
+      <br><br>
+      Maintainer: <a href="mailto:dahorak@redhat.com">Daniel Horak</a><br>
+      Team Contact: <a href="mailto:tendrl-devel@redhat.com">tendrl-devel</a><br>
+      JJB Code Location: <a href="https://github.com/Tendrl/tendrl-ci/tree/master/jobs">tendrl-ci</a><br>
+      Managed by Jenkins Job Builder. Do not edit via web.<br>
+    project-type: freestyle
+    package_prefix: "tendrl-"
+    defaults: global
+    disabled: false
+    concurrent: false
+    quiet-period: 0
+    block-downstream: false
+    block-upstream: false
+    node: 'tendrl-ci-slave01'
+    triggers: "{obj:triggers}"
+    scm: "{obj:scm}"
+    properties:
+      - github:
+          url: 'https://github.com/Tendrl/{package_name}/'
+    wrappers:
+      - timeout:
+          timeout: 60
+          abort: true
+          type: absolute
+    parameters:
+      - string:
+          name: ADDITIONAL_REPOS
+          default: ""
+          description: "Coma separated list of additional repos."
+      - string:
+          name: ADDITIONAL_REPOS_USM_SERVER
+          default: ""
+          description: "Coma separated list of additional repos."
+      - string:
+          name: ADDITIONAL_REPOS_USM_NODES
+          default: ""
+          description: "Coma separated list of additional repos."
+      - string:
+          name: ADDITIONAL_REPOS_USM_CLIENT
+          default: ""
+          description: "Coma separated list of additional repos."
+    builders:
+      - shell: |
+          #!/bin/bash -xe
+          echo
+          if [[ "${{ghprbPullId}}" ]]; then
+            echo "ghprbPullId: ${{ghprbPullId}}"
+            echo "ghprbCommentBody: ${{ghprbCommentBody}}"
+            echo "ghprbPullLongDescription: ${{ghprbPullLongDescription}}"
+            ADDITIONAL_REPOS="${{ADDITIONAL_REPOS}},http://artifacts.ci.centos.org/tendrl/pr/{package_prefix}{package_name}/pr${{ghprbPullId}}/{package_prefix}{package_name}-pr${{ghprbPullId}}.repo"
+            echo
+            echo "Parse ghprbCommentBody and ghprbPullLongDescription for dependent PRs."
+            # filter only lines containing "depends on:" string (and remove it)
+            # so it will iterate over list similar to this:
+            # tendrl-notifier/pr153 tendrl-commons/pr820 ...
+            for dependency in $(echo -e "${{ghprbCommentBody}}\n${{ghprbPullLongDescription}}" | \
+                grep -i "depends on:" | sed 's/depends on: //I'); do
+              package=${{dependency%/*}}
+              pr_id=${{dependency#*/}}
+              ADDITIONAL_REPOS="${{ADDITIONAL_REPOS}},http://artifacts.ci.centos.org/tendrl/pr/${{package}}/${{pr_id}}/${{package}}-${{pr_id}}.repo"
+            done
+            echo
+          fi
+
+          echo "Run whole test suite."
+          echo "##############################################################"
+          echo
+
+          # Prepare env.sh file
+          echo > ${{WORKSPACE}}/env.sh
+          echo "ADDITIONAL_REPOS=${{ADDITIONAL_REPOS}}" >> ${{WORKSPACE}}/env.sh
+          echo "ADDITIONAL_REPOS_USM_SERVER=${{ADDITIONAL_REPOS_USM_SERVER}}" >> ${{WORKSPACE}}/env.sh
+          echo "ADDITIONAL_REPOS_USM_NODES=${{ADDITIONAL_REPOS_USM_NODES}}" >> ${{WORKSPACE}}/env.sh
+          echo "ADDITIONAL_REPOS_USM_CLIENT=${{ADDITIONAL_REPOS_USM_CLIENT}}" >> ${{WORKSPACE}}/env.sh
+
+      - trigger-builds:
+        - project: "tendrl-2-cluster-gluster"
+          property-file: env.sh
+          block: true
+
+    publishers:
+      - email:
+          recipients: dahorak@redhat.com
+            
+
+- project:
+    name: 'Test_suite'
+    triggers:
+      - github-pull-request:
+          admin-list:
+            - dahorak
+          org-list:
+            - Tendrl
+          allow-whitelist-orgs-as-admins: true
+          trigger-phrase: '.*run test.*'
+          only-trigger-phrase: true
+          skip-build-phrase: 'no test'
+          github-hooks: true
+          cancel-builds-on-update: true
+          status-context: 'CentOS CI - tests'
+          status-add-test-results: false
+    scm:
+      - git:
+          url: 'https://github.com/Tendrl/{package_name}'
+          refspec: "+refs/pull/${{ghprbPullId}}/*:refs/remotes/origin/pr/${{ghprbPullId}}/*"
+          basedir: tendrl-{package_name}
+          skip-tag: true
+          wipe-workspace: true
+    jobs:
+      - "tendrl-pr-trigger-tests-{package_name}"
+    package_name:
+      - api
+      - commons
+      - gluster-integration
+      - monitoring-integration
+      - node-agent
+      - notifier
+      - tendrl-ansible:
+          package_prefix: ""
+      - tendrl-selinux:
+          package_prefix: ""
+      - ui

--- a/jobs/build-triggers/tendrl-build-triggers-pr-tests.yml
+++ b/jobs/build-triggers/tendrl-build-triggers-pr-tests.yml
@@ -87,6 +87,12 @@
 
           # Prepare env.sh file
           echo > ${{WORKSPACE}}/env.sh
+          # use cop tendrl/tendrl (master) repo
+          echo "TENDRL_REPO_URL=http://copr-be.cloud.fedoraproject.org/results/tendrl/tendrl/epel-7-x86_64/" >> ${{WORKSPACE}}/env.sh
+          echo "TENDRL_REPO_GPGKEY_URL=https://copr-be.cloud.fedoraproject.org/results/tendrl/tendrl/pubkey.gpg" >> ${{WORKSPACE}}/env.sh
+          echo "TENDRL_DEPENDENCIES_REPO_URL=http://copr-be.cloud.fedoraproject.org/results/tendrl/dependencies/epel-7-x86_64/" >> ${{WORKSPACE}}/env.sh
+          echo "TENDRL_DEPENDENCIES_REPO_GPGKEY_URL=https://copr-be.cloud.fedoraproject.org/results/tendrl/dependencies/pubkey.gpg" >> ${{WORKSPACE}}/env.sh
+          # configure additional repos
           echo "ADDITIONAL_REPOS=${{ADDITIONAL_REPOS}}" >> ${{WORKSPACE}}/env.sh
           echo "ADDITIONAL_REPOS_USM_SERVER=${{ADDITIONAL_REPOS_USM_SERVER}}" >> ${{WORKSPACE}}/env.sh
           echo "ADDITIONAL_REPOS_USM_NODES=${{ADDITIONAL_REPOS_USM_NODES}}" >> ${{WORKSPACE}}/env.sh

--- a/jobs/build-triggers/tendrl-build-triggers-pr-tests.yml
+++ b/jobs/build-triggers/tendrl-build-triggers-pr-tests.yml
@@ -114,9 +114,32 @@
       - github-pull-request:
           admin-list:
             - dahorak
+          white-list:
+            - a2batic
+            - cloudbehl
+            - fbalak
+            - gnehapk
+            - GowthamShanmugam
+            - julienlim
+            - ktdreyer
+            - ltrilety
+            - mbukatov
+            - mcarrano
+            - nnDarshan
+            - nthomas-redhat
+            - r0h4n
+            - rishubhjain
+            - sankarshanmukhopadhyay
+            - scuttlemonkey
+            - shirshendu
+            - shtripat
+            - sidhax
+            - tigert
+            - TimothyAsir
+            - TimothyAsirJeyasing
           org-list:
             - Tendrl
-          allow-whitelist-orgs-as-admins: true
+          allow-whitelist-orgs-as-admins: false
           trigger-phrase: '.*run test.*'
           only-trigger-phrase: true
           skip-build-phrase: 'no test'

--- a/jobs/build-triggers/tendrl-build-triggers.yml
+++ b/jobs/build-triggers/tendrl-build-triggers.yml
@@ -113,7 +113,7 @@
             condition: ALWAYS
 
       - email:
-          recipients: dahorak@redhat.com sds-mgmt-dev@redhat.com
+          recipients: dahorak@redhat.com
           send-to-individuals: false
 
 


### PR DESCRIPTION
Fixes https://github.com/Tendrl/tendrl-ci/issues/10

Jobs for launching test suite for every PR.

It will create one job for each repository.
The job might be triggered by `run tests` phrase in the respective PR.

It is possible to specify dependencies on PRs from other repos this way:

``Depends on: tendrl-ui/pr809 tendrl-notifier/pr153``

either in the PR description or in the comment triggering the test execution (or on both places).

It has to be on one line without any additional formatting and has to follow quite precisely this format, to be able to correctly (and easily) parse it.
Basically the line has to start with `depends on:` string (case insensitive) followed by space separated list of dependencies in the form of: `<reponame>/pr<id>`, where `<reponame>` is the name of the repository (including `tendrl-` prefix) and `<id>` is the PR number.