### PR TITLE
add yamllint config file

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,5 @@
+---
+extends: default
+
+rules:
+  line-length: disable

--- a/jobs/build-triggers/tendrl-build-triggers.yml
+++ b/jobs/build-triggers/tendrl-build-triggers.yml
@@ -115,7 +115,7 @@
       - email:
           recipients: dahorak@redhat.com sds-mgmt-dev@redhat.com
           send-to-individuals: false
-            
+
 
 - project:
     name: 'release'
@@ -134,8 +134,6 @@
     scm:
       - git:
           url: 'https://github.com/Tendrl/{package_name}'
-          #branches:
-          #  - "refs/heads/{branch}"
           refspec: "+refs/heads/{branch}:refs/remotes/origin/{branch}"
           basedir: tendrl-{package_name}
           skip-tag: true


### PR DESCRIPTION
- disable line-length rule, because accomplishing the strict requirement
  for line-length will lower readability and sometime it will not be
  possible at all in JJB config files